### PR TITLE
Resize Kaleidoscope layers to canvas size

### DIFF
--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/Kaleidoscope.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/Kaleidoscope.java
@@ -104,6 +104,9 @@ public class Kaleidoscope extends ExtPApplet
       height = 1000;
     }
     size(width, height, OPENGL); // keep size, but use the OpenGL renderer
+    previousWidth = width;
+    previousHeight = height;
+
     textureMode(NORMAL); // set texture coordinate mode to NORMALIZED (0 to 1)
 
     int smoothingLevel = DefaultValueParser.parseInt(this,
@@ -489,6 +492,8 @@ public class Kaleidoscope extends ExtPApplet
   }
 
 
+  private int previousWidth = -1, previousHeight = -1;
+
   @Override
   public void draw()
   {
@@ -497,6 +502,15 @@ public class Kaleidoscope extends ExtPApplet
       if (l != null)
         l.run();
     }
+
+    previousWidth = width;
+    previousHeight = height;
+  }
+
+
+  public boolean wasResized()
+  {
+    return width != previousWidth || height != previousHeight;
   }
 
 

--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/Kaleidoscope.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/Kaleidoscope.java
@@ -350,8 +350,26 @@ public class Kaleidoscope extends ExtPApplet
         centreLayer =
           new CentreMovingShape(this, null, 16, 150, getVolumeLevelProcessor())
       };
+      updateLayerSizes();
     }
     return layers;
+  }
+
+  private void updateLayerSizes()
+  {
+    float r = Math.min(width, height) / 1000f;
+
+    centreLayer.outerRadius = r * 150;
+    centreLayer.scaleFactor = r;
+
+    foobarLayer.innerRadius = r * 125;
+    foobarLayer.outerRadius = r * 275;
+
+    outerMovingShape.outerRadius = r * 300;
+
+    spectrogramLayer.innerRadius = r * 125;
+    spectrogramLayer.outerRadius = r * 290;
+    spectrogramLayer.scaleFactor = r * 5e-3f;
   }
 
   private OuterMovingShape getOuterMovingShape()
@@ -498,6 +516,9 @@ public class Kaleidoscope extends ExtPApplet
   public void draw()
   {
     drawBackgroundTexture();
+
+    if (wasResized())
+      updateLayerSizes();
     for (CircularLayer l : layers) {
       if (l != null)
         l.run();

--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/CentreMovingShape.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/CentreMovingShape.java
@@ -29,7 +29,7 @@ public class CentreMovingShape extends CircularLayer
   {
     double level = volumeLevelProcessor.getLevel();
     //System.out.println("Volume level: " + level);
-    float radius = outerRadius * (float) Math.pow(level, 0.5) * 1f;
+    float radius = outerRadius * (float) Math.pow(level, 0.5) * scaleFactor;
 
     parent.pushMatrix(); // use push/popMatrix so each Shape's translation does not affect other drawings
     parent.translate(parent.width / 2f, parent.height / 2f); // translate to the left-center

--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/CircularLayer.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/CircularLayer.java
@@ -13,6 +13,8 @@ public abstract class CircularLayer implements Runnable
 
   public float innerRadius, outerRadius;
 
+  public float scaleFactor = 1;
+
   public volatile PImageFuture currentImage;
 
   private final float[] xL, yL;

--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/CircularLayer.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/CircularLayer.java
@@ -32,10 +32,10 @@ public abstract class CircularLayer implements Runnable
 
   private void initAngles()
   {
-    float step = (float) (Math.PI * 2 / segmentCount); // generate the step size based on the number of segments
+    double step = Math.PI * 2 / segmentCount; // generate the step size based on the number of segments
     // pre-calculate x and y based on angle and store values in two arrays
     for (int i = 0; i < segmentCount; i++) {
-      float theta = step * i; // angle for this segment
+      double theta = step * i; // angle for this segment
       xL[i] = (float) Math.sin(theta);
       yL[i] = (float) Math.cos(theta);
     }

--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/OuterMovingShape.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/OuterMovingShape.java
@@ -48,10 +48,16 @@ public class OuterMovingShape extends CircularLayer
     parent.popMatrix(); // use push/popMatrix so each Shape's translation does not affect other drawings
   }
 
+
+  private PitchDetectionHandler pitchDetectionHandler = null;
+
   public PitchDetectionHandler getPitchDetectionHandler()
   {
-    return new MyPitchDetectionHandler();
+    if (pitchDetectionHandler == null)
+      pitchDetectionHandler = new MyPitchDetectionHandler();
+    return pitchDetectionHandler;
   }
+
 
   private class MyPitchDetectionHandler implements PitchDetectionHandler
   {

--- a/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/SpectrogramLayer.java
+++ b/Kaleidoscope/src/kaleidok/examples/kaleidoscope/layer/SpectrogramLayer.java
@@ -19,6 +19,7 @@ public class SpectrogramLayer extends CircularLayer
     int innerRadius, int outerRadius, MinimFFTProcessor spectrum )
 	{
 		super(parent, img, segmentCount, innerRadius, outerRadius);
+		scaleFactor = 5e-3f;
     avgSpectrum = spectrum;
 
     double nyquistFreq = 22050 / 2;
@@ -51,7 +52,7 @@ public class SpectrogramLayer extends CircularLayer
 	  {
 	    int imi = i % segmentCount; // make sure the end equals the start
 
-	    float dynamicOuter = (float) pow(avgSpectrum.get(imi), 1.125f) * 5e-3f;
+	    float dynamicOuter = (float) pow(avgSpectrum.get(imi), 1.125f) * scaleFactor;
 	    //System.out.println(dynamicOuter);
 
 	    drawCircleVertex(imi, innerRadius); // draw the vertex using the custom drawVertex() method


### PR DESCRIPTION
The size of the Kaleidoscope is now a fixed ratio of the length of the shortest canvas edge. For now I maintained the original size ratios compared to the default canvas size of 1000×1000. These can be altered in [`Kaleidoscope#updateLayerSizes()`](#diff-7ac9ccf20428a50467712fa64ee35149R358).

Textures aren't resized at all (for now), so they may turn out too small or too large. If this is an issue, please submit an issue report and refer to this pull request.

Overall it would be better and easier to use the transformation matrix stack to scale shapes *and* textures.