### PR TITLE
Desaturate neutral images

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -304,6 +304,7 @@
       <option name="ignoreRequiredObsoleteCollectionTypes" value="true" />
     </inspection_tool>
     <inspection_tool class="OptionalContainsCollection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="OptionalUsedAsFieldOrParameterType" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInMatchingInstanceof" value="false" />
     </inspection_tool>

--- a/Kaleidoscope/Kaleidoscope.iml
+++ b/Kaleidoscope/Kaleidoscope.iml
@@ -18,5 +18,6 @@
     <orderEntry type="library" name="Processing 3.1" level="application" />
     <orderEntry type="module" module-name="TarsosDSP" />
     <orderEntry type="library" name="commons-io:commons-io:2.4" level="project" />
+    <orderEntry type="library" name="org.apache.commons:commons-lang3:3.4" level="project" />
   </component>
 </module>

--- a/Kaleidoscope/src/kaleidok/kaleidoscope/KaleidoscopeChromasthetiationService.java
+++ b/Kaleidoscope/src/kaleidok/kaleidoscope/KaleidoscopeChromasthetiationService.java
@@ -2,6 +2,7 @@ package kaleidok.kaleidoscope;
 
 import kaleidok.exaleads.chromatik.ChromasthetiationService;
 import kaleidok.exaleads.chromatik.DocumentChromasthetiator;
+import kaleidok.exaleads.chromatik.data.ChromatikResponse;
 import kaleidok.processing.image.PImages;
 import kaleidok.util.concurrent.AbstractFutureCallback;
 import kaleidok.util.concurrent.GroupedThreadFactory;
@@ -13,10 +14,13 @@ import kaleidok.http.cache.ExecutorSchedulingStrategy;
 import kaleidok.io.platform.PlatformPaths;
 import kaleidok.processing.image.PImageFuture;
 import kaleidok.util.prefs.DefaultValueParser;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.client.fluent.Async;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import synesketch.emotion.Emotion;
+import synesketch.emotion.EmotionalState;
 
 import java.awt.Image;
 import java.io.File;
@@ -180,14 +184,15 @@ public final class KaleidoscopeChromasthetiationService
 
 
   private class ChromasthetiationCallback
-    extends AbstractFutureCallback<Image>
+    extends AbstractFutureCallback<Pair<Image, Pair<ChromatikResponse, EmotionalState>>>
   {
     private final AtomicInteger imageListIndex = new AtomicInteger(0);
 
 
     @Override
-    public void completed( Image image )
+    public void completed( Pair<Image, Pair<ChromatikResponse, EmotionalState>> response )
     {
+      Image image = response.getLeft();
       assert image.getWidth(null) > 0 && image.getHeight(null) > 0 :
         image + " has width or height ≤0";
       PImageFuture fImage = PImageFuture.from(PImages.from(image));

--- a/Kaleidoscope/src/kaleidok/kaleidoscope/KaleidoscopeChromasthetiationService.java
+++ b/Kaleidoscope/src/kaleidok/kaleidoscope/KaleidoscopeChromasthetiationService.java
@@ -208,7 +208,7 @@ public final class KaleidoscopeChromasthetiationService
       {
         RGBImageFilter filter = getNeutralFilter();
         if (filter != null)
-          pImage = PImages.filter(pImage, pImage, filter);
+          pImage = PImages.filter(pImage, pImage, (RGBImageFilter) filter.clone());
       }
       PImageFuture fImage = PImageFuture.from(pImage);
 

--- a/Kaleidoscope/src/kaleidok/kaleidoscope/KaleidoscopeChromasthetiationService.java
+++ b/Kaleidoscope/src/kaleidok/kaleidoscope/KaleidoscopeChromasthetiationService.java
@@ -3,6 +3,7 @@ package kaleidok.kaleidoscope;
 import kaleidok.exaleads.chromatik.ChromasthetiationService;
 import kaleidok.exaleads.chromatik.DocumentChromasthetiator;
 import kaleidok.exaleads.chromatik.data.ChromatikResponse;
+import kaleidok.image.filter.Parser;
 import kaleidok.processing.image.PImages;
 import kaleidok.util.concurrent.AbstractFutureCallback;
 import kaleidok.util.concurrent.GroupedThreadFactory;
@@ -19,14 +20,17 @@ import org.apache.http.client.fluent.Async;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import processing.core.PImage;
 import synesketch.emotion.Emotion;
 import synesketch.emotion.EmotionalState;
 
 import java.awt.Image;
+import java.awt.image.RGBImageFilter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -188,6 +192,8 @@ public final class KaleidoscopeChromasthetiationService
   {
     private final AtomicInteger imageListIndex = new AtomicInteger(0);
 
+    private Optional<RGBImageFilter> neutralFilter = null;
+
 
     @Override
     public void completed( Pair<Image, Pair<ChromatikResponse, EmotionalState>> response )
@@ -195,7 +201,16 @@ public final class KaleidoscopeChromasthetiationService
       Image image = response.getLeft();
       assert image.getWidth(null) > 0 && image.getHeight(null) > 0 :
         image + " has width or height ≤0";
-      PImageFuture fImage = PImageFuture.from(PImages.from(image));
+      PImage pImage = PImages.from(image);
+
+      EmotionalState emoState = response.getRight().getRight();
+      if (emoState.getStrongestEmotion().getType() == Emotion.NEUTRAL)
+      {
+        RGBImageFilter filter = getNeutralFilter();
+        if (filter != null)
+          pImage = PImages.filter(pImage, pImage, filter);
+      }
+      PImageFuture fImage = PImageFuture.from(pImage);
 
       LayerManager layers = parent.getLayers();
       int idx = imageListIndex.getAndIncrement() % layers.size();
@@ -221,6 +236,32 @@ public final class KaleidoscopeChromasthetiationService
         }
       }
       super.failed(ex);
+    }
+
+
+    private RGBImageFilter getNeutralFilter()
+    {
+      if (neutralFilter == null)
+      {
+        @SuppressWarnings("TooBroadScope")
+        String
+          paramName =
+            parent.getClass().getPackage().getName() +
+              ".images.filter.neutral",
+          filterStr = parent.getParameterMap().get(paramName);
+        try
+        {
+          neutralFilter = Optional.ofNullable(
+            (filterStr != null) ? Parser.parseFilter(filterStr) : null);
+        }
+        catch (IllegalArgumentException | UnsupportedOperationException ex)
+        {
+          logThrown(logger, Level.WARNING,
+            "{0} ignored: illegal image filter value", ex, paramName);
+          neutralFilter = Optional.empty();
+        }
+      }
+      return neutralFilter.orElse(null);
     }
   }
 

--- a/libraries/src/kaleidok/image/filter/HSBAdjustFilter.java
+++ b/libraries/src/kaleidok/image/filter/HSBAdjustFilter.java
@@ -1,0 +1,46 @@
+package kaleidok.image.filter;
+
+import kaleidok.util.function.BinaryFloatFunction;
+
+import static kaleidok.util.Math.clamp;
+
+
+public class HSBAdjustFilter extends HSBImageFilter
+{
+  public float hue, saturation, brightness;
+
+  public BinaryFloatFunction filterMode;
+
+
+  public HSBAdjustFilter( float hue, float saturation, float brightness,
+    BinaryFloatFunction filterMode )
+  {
+    this.hue = hue;
+    this.saturation = saturation;
+    this.brightness = brightness;
+    this.filterMode = filterMode;
+    canFilterIndexColorModel = true;
+  }
+
+
+  public HSBAdjustFilter( float hue, float saturation, float brightness )
+  {
+    this(hue, saturation, brightness, (left, right) -> left + right);
+  }
+
+
+  public HSBAdjustFilter()
+  {
+    this(0, 0, 0);
+  }
+
+
+  @Override
+  public float[] filterHSB( int x, int y, float[] hsb )
+  {
+    hsb[0] = filterMode.applyAsFloat(hsb[0], hue) % (float)(Math.PI * 2);
+    hsb[1] = clamp(filterMode.applyAsFloat(hsb[1], saturation), 0, 1);
+    hsb[2] = clamp(filterMode.applyAsFloat(hsb[2], brightness), 0, 1);
+    return hsb;
+  }
+}

--- a/libraries/src/kaleidok/image/filter/HSBImageFilter.java
+++ b/libraries/src/kaleidok/image/filter/HSBImageFilter.java
@@ -1,0 +1,32 @@
+package kaleidok.image.filter;
+
+import java.awt.Color;
+import java.awt.image.RGBImageFilter;
+
+
+public abstract class HSBImageFilter extends RGBImageFilter
+{
+  private float[] hsbBuf = new float[3];
+
+
+  public abstract float[] filterHSB( int x, int y, float[] hsb );
+
+
+  @Override
+  public int filterRGB( int x, int y, int rgb )
+  {
+    float[] transformedHSB = filterHSB(x, y, Color.RGBtoHSB(
+      (rgb >>> 16) & 0xff, (rgb >>> 8) & 0xff, rgb & 0xff, hsbBuf));
+    return Color.HSBtoRGB(
+      transformedHSB[0], transformedHSB[1], transformedHSB[2]);
+  }
+
+
+  @Override
+  public HSBImageFilter clone()
+  {
+    HSBImageFilter copy = (HSBImageFilter) super.clone();
+    copy.hsbBuf = copy.hsbBuf.clone();
+    return copy;
+  }
+}

--- a/libraries/src/kaleidok/image/filter/Parser.java
+++ b/libraries/src/kaleidok/image/filter/Parser.java
@@ -1,0 +1,88 @@
+package kaleidok.image.filter;
+
+import kaleidok.util.function.BinaryFloatFunction;
+
+import java.awt.image.RGBImageFilter;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.DoubleStream;
+
+
+public final class Parser
+{
+  public static final Pattern IMAGE_FILTER_SPEC_PATTERN = Pattern.compile(
+    "^(?<operator>[*/+-]?)\\s*(?<colormodel>\\w+)\\s*\\(\\s*(?<args>[^\\s,)]+(?:\\s*,\\s*[^\\s,)]+)*)\\s*\\)",
+    Pattern.CASE_INSENSITIVE);
+
+  public static final Pattern ARGUMENT_DELIMITER_PATTERN = Pattern.compile("\\s*,\\s*");
+
+
+  private Parser() { }
+
+
+  public static RGBImageFilter parseFilter( String s )
+  {
+    if (s.isEmpty())
+      return null;
+
+    Matcher m = IMAGE_FILTER_SPEC_PATTERN.matcher(s);
+    if (!m.matches())
+      throw new IllegalArgumentException("Invalid filter spec: " + s);
+
+    double[] args =
+      ARGUMENT_DELIMITER_PATTERN.splitAsStream(m.group("args"))
+        .mapToDouble(Double::parseDouble).toArray();
+    if (!DoubleStream.of(args).allMatch(Double::isFinite))
+    {
+      throw new IllegalArgumentException(
+        "Non-finite argument value encountered: " + m.group("args"));
+    }
+
+    int operatorStart = m.start("operator"),
+      operatorLen = m.end("operator") - operatorStart;
+    char operatorChar =
+      (operatorLen == 1) ? s.charAt(operatorStart) :
+      (operatorLen == 0) ? '+' :
+        '\0';
+    BinaryFloatFunction operator;
+    switch (operatorChar)
+    {
+    case '+':
+      operator = (a, b) -> a + b;
+      break;
+
+    case '-':
+      operator = (a, b) -> a - b;
+      break;
+
+    case '*':
+      operator = (a, b) -> a * b;
+      break;
+
+    case '/':
+      operator = (a, b) -> a / b;
+      break;
+
+    default:
+      throw new AssertionError("Unexpected operator");
+    }
+
+    switch (m.group("colormodel").toLowerCase(Locale.ROOT))
+    {
+    case "hsb":
+      if (args.length != 3)
+      {
+        throw new IllegalArgumentException(
+          "hsb() expects 3 arguments, " + args.length + " given");
+      }
+      return new HSBAdjustFilter(
+        (float) args[0], (float) args[1], (float) args[2], operator);
+
+    case "rgb":
+    default:
+      throw new UnsupportedOperationException(
+        "Unknown or unimplemented color model: " + m.group("colormodel"));
+    }
+  }
+}

--- a/libraries/src/kaleidok/processing/image/PImages.java
+++ b/libraries/src/kaleidok/processing/image/PImages.java
@@ -10,6 +10,7 @@ import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
+import java.awt.image.RGBImageFilter;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -182,5 +183,36 @@ public final class PImages
       return readers.next();
 
     throw new IllegalArgumentException("No suitable image decoder found");
+  }
+
+
+  @SuppressWarnings("AssignmentToForLoopParameter")
+  public static PImage filter( PImage src, PImage dst, RGBImageFilter filter )
+  {
+    if (filter ==  null)
+      throw new NullPointerException("filter");
+
+    src.loadPixels();
+    int width = src.width, height = src.height;
+    int[] spx = src.pixels;
+
+    if (dst == null)
+      dst = new PImage();
+    if (src != dst)
+      dst.init(width, height, src.format, src.pixelDensity);
+    dst.loadPixels();
+    int[] dpx = dst.pixels;
+
+    for (int i = 0, y = 0; y < height; y++)
+    {
+      for (int x = 0; x < width; x++, i++)
+      {
+        int px = spx[i];
+        dpx[i] = filter.filterRGB(x, y, px & 0x00ffffff) | (px & 0xff000000);
+      }
+    }
+
+    dst.updatePixels();
+    return dst;
   }
 }

--- a/libraries/src/kaleidok/util/Math.java
+++ b/libraries/src/kaleidok/util/Math.java
@@ -115,19 +115,25 @@ public final class Math
 
   public static long clamp( long x, long min, long max )
   {
-    assert min <= max : min + " > " + max;
+    //assert min <= max : min + " > " + max;
     return min(max(x, min), max);
   }
 
   public static int clamp( int x, int min, int max )
   {
-    assert min <= max : min + " > " + max;
+    //assert min <= max : min + " > " + max;
     return min(max(x, min), max);
   }
 
   public static double clamp( double x, double min, double max )
   {
-    assert min <= max : min + " > " + max;
+    //assert min <= max : min + " > " + max;
+    return min(max(x, min), max);
+  }
+
+  public static float clamp( float x, float min, float max )
+  {
+    //assert min <= max : min + " > " + max;
     return min(max(x, min), max);
   }
 

--- a/libraries/src/kaleidok/util/containers/BoundedCompletionQueue.java
+++ b/libraries/src/kaleidok/util/containers/BoundedCompletionQueue.java
@@ -21,7 +21,7 @@ public class BoundedCompletionQueue<E> implements Queue<E>
 
   private Collection<E> removedItems;
 
-  public Consumer<Collection<? super E>> completionCallback = null;
+  public Consumer<Collection<E>> completionCallback = null;
 
 
   private BoundedCompletionQueue( Queue<E> underlying, int permits, int capacityHint )
@@ -113,7 +113,7 @@ public class BoundedCompletionQueue<E> implements Queue<E>
 
   protected void doCompletionCallback()
   {
-    Consumer<Collection<? super E>> completionCallback =
+    Consumer<Collection<E>> completionCallback =
       this.completionCallback;
     if (completionCallback != null)
       completionCallback.accept(removedItems);

--- a/libraries/src/kaleidok/util/function/BinaryFloatFunction.java
+++ b/libraries/src/kaleidok/util/function/BinaryFloatFunction.java
@@ -1,0 +1,6 @@
+package kaleidok.util.function;
+
+public interface BinaryFloatFunction
+{
+  float applyAsFloat( float left, float right );
+}


### PR DESCRIPTION
Pull request for issue #49.

There's a property for the filter specification. To reduce saturation to a quarter one would write:

```
kaleidok.kaleidoscope.images.filter.neutral=*hsb(1, 0.25, 1)
```
